### PR TITLE
feat: rounding + checked APIs (OZ-inspired)

### DIFF
--- a/sources/rounding.move
+++ b/sources/rounding.move
@@ -1,0 +1,20 @@
+module gaussian::rounding;
+
+/// Enumerates rounding strategies used by arithmetic helpers.
+/// - Down: round toward zero (truncate).
+/// - Up: round away from zero (ceiling).
+/// - Nearest: round to closest integer, ties round up.
+public enum RoundingMode has copy, drop {
+    Down,
+    Up,
+    Nearest,
+}
+
+/// Helper returning the enum value for downward rounding.
+public fun down(): RoundingMode { RoundingMode::Down }
+
+/// Helper returning the enum value for upward rounding.
+public fun up(): RoundingMode { RoundingMode::Up }
+
+/// Helper returning the enum value for nearest rounding (ties round up).
+public fun nearest(): RoundingMode { RoundingMode::Nearest }

--- a/sources/signed_wad.move
+++ b/sources/signed_wad.move
@@ -35,10 +35,12 @@ const SCALE: u256 = 1_000_000_000_000_000_000;
 // === Errors ===
 
 /// Division by zero.
-const EDivisionByZero: u64 = 10;
+#[error(code = 10)]
+const EDivisionByZero: vector<u8> = b"Divisor must be non-zero.";
 
 /// Unexpected negative value where only non-negative is allowed.
-const EUnexpectedNegative: u64 = 11;
+#[error(code = 11)]
+const EUnexpectedNegative: vector<u8> = b"Unexpected negative value.";
 
 // === Structs ===
 

--- a/tests/api_misuse.move
+++ b/tests/api_misuse.move
@@ -1,0 +1,35 @@
+/// API boundary misuse tests (abort paths + checked alternatives).
+module gaussian::api_misuse;
+
+use gaussian::math;
+use gaussian::normal_inverse;
+use gaussian::sampling;
+
+#[test, expected_failure(abort_code = math::EDivisionByZero)]
+fun div_scaled_aborts_on_zero_denominator() {
+    let _ = math::div_scaled(1, 0);
+}
+
+#[test]
+fun div_scaled_checked_returns_none_on_zero_denominator() {
+    let result = math::div_scaled_checked(1, 0);
+    assert!(option::is_none(&result), 0);
+}
+
+#[test, expected_failure(abort_code = normal_inverse::EProbOutOfDomain)]
+fun ppf_aborts_on_out_of_domain_probability() {
+    let _ = normal_inverse::ppf(0);
+}
+
+#[test]
+fun ppf_checked_returns_none_on_out_of_domain_probability() {
+    let result = normal_inverse::ppf_checked(0);
+    assert!(option::is_none(&result), 0);
+}
+
+#[test, expected_failure(abort_code = sampling::ERandomAlreadyUsed)]
+fun sampler_guard_blocks_reuse() {
+    let mut guard = sampling::new_sampler_guard();
+    let _ = sampling::sample_z_from_u64_guarded(1, &mut guard);
+    let _ = sampling::sample_z_from_u64_guarded(2, &mut guard);
+}

--- a/tests/boundary_exploit.move
+++ b/tests/boundary_exploit.move
@@ -661,7 +661,7 @@ fun test_signed_wad_division_edge_cases() {
 ///
 /// Exploit attempt: Cause division by zero.
 #[test]
-#[expected_failure(abort_code = 10)]
+#[expected_failure(abort_code = signed_wad::EDivisionByZero)]
 fun test_signed_wad_division_by_zero_aborts() {
     let one = signed_wad::from_wad(SCALE);
     let zero = signed_wad::zero();

--- a/tests/security_audit.move
+++ b/tests/security_audit.move
@@ -713,7 +713,7 @@ fun test_coefficient_consistency_roundtrip() {
 ///
 /// Expected: Abort with EDivisionByZero (2).
 #[test]
-#[expected_failure(abort_code = 2)]
+#[expected_failure(abort_code = math::EDivisionByZero)]
 fun test_div_scaled_zero_denominator_aborts() {
     let _result = math::div_scaled(SCALE, 0);
 }


### PR DESCRIPTION
Implements OZ-inspired ergonomics for gaussian:\n\n- Add gaussian::rounding (RoundingMode)\n- Add rounding-aware helpers (mul_div_round, div_scaled_round)\n- Add Option-returning checked APIs (div_scaled_checked, ppf_checked)\n- Add API misuse tests for abort vs checked behavior\n\nNotes: Move #[error(code=...)] requires u8 codes, so only small-code errors were migrated; 300+/400+ codes remain u64.